### PR TITLE
fix: fix get value from image column

### DIFF
--- a/src/widgets/columns/ImageColumn.php
+++ b/src/widgets/columns/ImageColumn.php
@@ -105,11 +105,11 @@ class ImageColumn extends DataColumn
      * @param mixed $key the key associated with the data model
      * @param int $index the zero-based index of the data model among the models array returned by [[GridView::dataProvider]].
      * @param null|string image attribute for child classes
-     * @return string image url
+     * @return string|null image url
      */
     protected function getImageUrl($model, $key, $index, $attribute)
     {
-        $imgUrl = false;
+        $imgUrl = null;
 
         if (is_object($model) && method_exists($model, 'getBehaviors')) {
 
@@ -129,10 +129,6 @@ class ImageColumn extends DataColumn
                     break;
                 }
             }
-        }
-
-        if (!$imgUrl) {
-            $imgUrl = $this->getAttributeCellValue($model, $key, $index, $attribute);
         }
 
         return $imgUrl;


### PR DESCRIPTION
![2018-11-07 17-15-25](https://user-images.githubusercontent.com/20629188/48131167-56546a00-e2b9-11e8-80f6-5804ed2f7552.png)
При использовании TitledImageColumn, если изображение не загружено, то в `src` изображения подставлялся заголовок. В этом коммите сделал так, чтобы `src` вообще было в атрибутах  изображения в случае если картинка не загружена.