### PR TITLE
fix: change migration commands order

### DIFF
--- a/bin/bridge-install
+++ b/bin/bridge-install
@@ -1,6 +1,6 @@
 #!/bin/bash
 ./yii migrate --migrationPath=@Zelenin/yii/modules/I18n/migrations --interactive=0
-./yii migrate --migrationNamespaces=Da\\User\\Migration --interactive=0
 ./yii migrate --migrationPath=@yii/rbac/migrations --interactive=0
 ./yii migrate --migrationPath=@bridge-migrations --interactive=0
+./yii migrate --migrationNamespaces=Da\\User\\Migration --interactive=0
 ./yii migrate --interactive=0


### PR DESCRIPTION
@naffiq Изменил порядок запуска миграции, потому что при запуске команды `./yii migrate --migrationNamespaces=Da\\User\\Migration --interactive=0`, после применение миграции **2amigos/usuarion** выполняется и миграции самого проекта `./yii migrate --interactive=0`