### PR TITLE
fix: fix image column

### DIFF
--- a/src/widgets/columns/ImageColumn.php
+++ b/src/widgets/columns/ImageColumn.php
@@ -114,7 +114,7 @@ class ImageColumn extends DataColumn
         if (is_object($model) && method_exists($model, 'getBehaviors')) {
 
             foreach ($model->getBehaviors() as $behavior) {
-                if ($behavior::className() == BridgeUploadImageBehavior::class && $behavior->attribute == $attribute) {
+                if (($behavior instanceof BridgeUploadImageBehavior) && ($behavior->attribute === $attribute)) {
                     /**
                      * @var $behavior BridgeUploadImageBehavior
                      */


### PR DESCRIPTION
В одном из проектов, мне пришлось немного изменить логику загрузки изображении наследуя от `BridgeUploadImageBehavior`. Но после этого у меня перестало работать `ImageColumn` и `TitledImageColumn`